### PR TITLE
Fixes missing include directory to Boost

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -16,7 +16,7 @@ set_target_properties(clang_common PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(plugin PROPERTIES
   PREFIX ""
   OUTPUT_NAME "i18n-clang")
-target_include_directories(clang_common PUBLIC ${LLVM_INCLUDE_DIRS})
+target_include_directories(clang_common PUBLIC ${LLVM_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
 target_compile_definitions(clang_common PUBLIC ${LLVM_DEFINITIONS})
 target_compile_features(clang_common PUBLIC cxx_std_17)
 if(${LLVM_ENABLE_RTTI})


### PR DESCRIPTION
Compilation is failing on macOS due to missing includes of Boost. This PR fixes this issue.

```
[1/88] Building CXX object clang/CMakeFiles/clang_common.dir/__/common/write_po.cpp.o
FAILED: clang/CMakeFiles/clang_common.dir/__/common/write_po.cpp.o 
/opt/local/bin/clang++ -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/opt/local/libexec/llvm-13/include -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.1.sdk -fPIC -frtti -std=c++17 -MD -MT clang/CMakeFiles/clang_common.dir/__/common/write_po.cpp.o -MF clang/CMakeFiles/clang_common.dir/__/common/write_po.cpp.o.d -o clang/CMakeFiles/clang_common.dir/__/common/write_po.cpp.o -c /Users/ferrao/Documents/Development/i18n++/common/write_po.cpp
In file included from /Users/ferrao/Documents/Development/i18n++/common/write_po.cpp:1:
/Users/ferrao/Documents/Development/i18n++/common/../common/ast.hpp:2:10: fatal error: 'boost/spirit/home/x3/support/ast/position_tagged.hpp' file not found
#include <boost/spirit/home/x3/support/ast/position_tagged.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[18/88] Building CXX object external/Catch2/src/...tch2.dir/catch2/internal/catch_commandline.cpp.o
ninja: build stopped: subcommand failed.
```
